### PR TITLE
Fix typo [skip ci]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - make  # [unix]
     - libtool  # [unix]
     - m2-patch    # [win]
- test:
+
+test:
   commands:
     - test -f ${PREFIX}/lib/libpixman-1.a  # [not win]
 


### PR DESCRIPTION
Just fixing a small typo that prevents percy from rendering the recipe correctly.