### PR TITLE
pixman rebuild win-arm64 support

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,11 @@
 :: get the prefix in "mixed" form
 set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
 
+set "EXTRA_MESON_ARGS="
+if "%ARCH%"=="arm64" (
+  set "EXTRA_MESON_ARGS=-Da64-neon=disabled -Dmmx=disabled -Dsse2=disabled -Dssse3=disabled"
+)
+
 %BUILD_PREFIX%\Scripts\meson setup builddir ^
   --buildtype=release ^
   --prefix=%LIBRARY_PREFIX_M% ^
@@ -10,7 +15,8 @@ set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
   --default-library=shared ^
   --wrap-mode=nofallback ^
   -Dtests=enabled ^
-  --backend=ninja
+  --backend=ninja ^
+  %EXTRA_MESON_ARGS%
 if errorlevel 1 exit 1
 
 ninja -v -C builddir -j %CPU_COUNT%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -8,7 +8,7 @@ if "%ARCH%"=="arm64" (
   set "EXTRA_MESON_ARGS=-Dmmx=disabled -Dsse2=disabled -Dssse3=disabled"
 )
 
-%BUILD_PREFIX%\Scripts\meson setup builddir ^
+meson setup builddir ^
   --buildtype=release ^
   --prefix=%LIBRARY_PREFIX_M% ^
   --libdir=lib ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,7 +5,7 @@ set "LIBRARY_PREFIX_M=%LIBRARY_PREFIX:\=/%"
 
 set "EXTRA_MESON_ARGS="
 if "%ARCH%"=="arm64" (
-  set "EXTRA_MESON_ARGS=-Da64-neon=disabled -Dmmx=disabled -Dsse2=disabled -Dssse3=disabled"
+  set "EXTRA_MESON_ARGS=-Dmmx=disabled -Dsse2=disabled -Dssse3=disabled"
 )
 
 %BUILD_PREFIX%\Scripts\meson setup builddir ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://cairographics.org/releases/{{ name }}-{{ version }}.tar.gz
   sha256: d09c44ebc3bd5bee7021c79f922fe8fb2fb57f7320f55e97ff9914d2346a591c
   patches:
-    - patches/0001-meson-darwin-versions.patch
+    - patches/0001-meson-darwin-versions.patch  # [osx]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-meson-darwin-versions.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('pixman') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,10 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
-    - meson
     - ninja-base
     - pkg-config
+  host:
+    - meson
 
 test:
   commands:


### PR DESCRIPTION
pixman rebuild win-arm64 support

**Destination channel:** defaults

### Links

- [PKG-15406](https://anaconda.atlassian.net/browse/PKG-15406) 


### Explanation of changes:

- Disable x86 SIMD instruction sets on win-arm64.
- Move meson to host and fix bld.bat


[PKG-15406]: https://anaconda.atlassian.net/browse/PKG-15406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ